### PR TITLE
Do not define strerror_s in C11 mode

### DIFF
--- a/vendor/compat-5.3/c-api/compat-5.3.c
+++ b/vendor/compat-5.3/c-api/compat-5.3.c
@@ -37,7 +37,7 @@
 #endif /* strerror_r */
 
 #ifndef COMPAT53_HAVE_STRERROR_S
-#  if defined(_MSC_VER) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || \
+#  if defined(_MSC_VER) || \
       (defined(__STDC_LIB_EXT1__) && __STDC_LIB_EXT1__)
 #    define COMPAT53_HAVE_STRERROR_S 1
 #  else /* not VC++ or C11 */


### PR DESCRIPTION
strerror_s is a Microsoft extension that creeped its way into the standard.
It is not implemented anywhere else.