### PR TITLE
src/ldbus: Fix tostring() message on objects without __udtype

### DIFF
--- a/src/ldbus.c
+++ b/src/ldbus.c
@@ -14,7 +14,7 @@
 
 int tostring(lua_State *L) {
 	if (!luaL_getmetafield(L, 1, "__udtype")) {
-		lua_pushstring(L, "object with a generic __tostring metamethod but no __type metafield");
+		lua_pushstring(L, "object with a generic __tostring metamethod but no __udtype metafield");
 	}
 	lua_pushfstring(L, "%s: %p", lua_tostring(L, -1), lua_topointer(L, -2));
 	return 1;


### PR DESCRIPTION
The customized __tostring() metamethod checks for __udtype metafield and format a friendly string according to its content. Here the message in case of missing __udtype is inaccurate, the missing field is "__udtype" instead of "__type".

Although there's no wrapper types without "__udtype" set in ldbus, this may help future debugging.

Fixes: 7e3b419 ("first commit")